### PR TITLE
Added function to override embargo_date year range for islandora_scholar_embargo

### DIFF
--- a/presbydora.module
+++ b/presbydora.module
@@ -110,3 +110,19 @@ function presbydora_remove_solr_metadata_fields(&$variables, $key) {
     }
   }
 }
+
+/**
+ * Implements hook_form_islandora_scholar_embargo_alter().
+ */
+function presbydora_form_islandora_scholar_embargo_form_alter(&$form, &$form_state, $form_id) {
+  $form['embargo_date']['#after_build'] = array('presbydora_embargo_date_set_year_range');
+}
+
+/**
+ * Override original year range.
+ */
+function presbydora_embargo_date_set_year_range($form_element, $form_values) {
+  $year = date("Y");
+  $form_element['year']['#options'] = drupal_map_assoc(range($year, $year + 500));
+  return $form_element;
+}


### PR DESCRIPTION
A little more passive attempt at allowing the user to specify a wider range of years for the islandora_scholar_embargo embargo_date form element.

500 years was an arbitrary number I chose, but the client never did specify a maximum. I figure we won't even be around for 500 more years so who would need to preserve data for that long :-)