### PR TITLE
alter user pass form error message

### DIFF
--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -87,3 +87,41 @@ function presbydora_get_ancestors($pid) {
   }
   return $ancestors;
 }
+
+/**
+ * Custom validation for user password reset.
+ *
+ * This function is used to cover D7's security bug that reveals whether an
+ * email or username is in use, see:
+ * https://www.drupal.org/project/drupal/issues/1521996.
+ */
+function presbydora_user_pass_validate(&$form, &$form_state) {
+  $name = trim($form_state['values']['name']);
+  // Try to load by email.
+  $users = user_load_multiple(array(), array('mail' => $name, 'status' => '1'));
+  $account = reset($users);
+  if (!$account) {
+    // No success, try to load by name.
+    $users = user_load_multiple(array(), array('name' => $name, 'status' => '1'));
+    $account = reset($users);
+  }
+  if (isset($account->uid)) {
+    form_set_value(array('#parents' => array('account')), $account, $form_state);
+  }
+  else {
+    $form['#submit'] = array('presbydora_user_pass_submit');
+  }
+}
+
+/**
+ * Custom user password reset submit function.
+ *
+ * This function is used to cover D7's security bug that reveals whether an
+ * email or username is in use, see:
+ * https://www.drupal.org/project/drupal/issues/1521996.
+ */
+function presbydora_user_pass_submit($form, &$form_state) {
+  drupal_set_message(t('Further instructions have been sent to your e-mail address.'));
+  $form_state['redirect'] = 'user';
+  return;
+}

--- a/presbydora.module
+++ b/presbydora.module
@@ -316,3 +316,11 @@ function presbydora_islandora_collectioncmodel_islandora_object_purged($pid) {
     variable_set('presbydora_access_bypass_pids', $bypass_pids);
   }
 }
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
+function presbydora_form_user_pass_alter(&$form, &$form_state, $form_id) {
+  module_load_include('inc', 'presbydora', 'includes/utilities');
+  $form['#validate'] = array('presbydora_user_pass_validate');
+}


### PR DESCRIPTION
This function is used to cover D7's security bug that reveals whether anemail or username is in use, see: https://www.drupal.org/project/drupal/issues/1521996.